### PR TITLE
Use flat config by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,12 @@ pnpm add -D eslint-plugin-handle-errors
 (**eslint.config.js**)
 
 ```javascript
+import eslint from '@eslint/js';
 import handleErrors from 'eslint-plugin-handle-errors';
 
 export default [
-    {
-        files: ['src/**'],
-        ...handleErrors.configs['flat/recommended'],
-    },
+    eslint.configs.recommended, // optional
+    handleErrors.configs.recommended,
 ];
 ```
 
@@ -45,7 +44,7 @@ export default [
 
 ```json
 {
-    "extends": ["plugin:handle-errors/recommended"],
+    "extends": ["plugin:handle-errors/legacy-recommended"],
 }
 ```
 
@@ -55,19 +54,21 @@ export default [
 
 You can customize the logger functions that are used to log errors in your project.
 
-```json
-{
-    "settings": {
-        "handleErrors": {
-            "loggerFunctions": [
-                "console.error", 
-                "console.warn", 
-                "Sentry.captureException", 
-                "logError"
-            ]
-        }
-    }
-}
+```js
+import eslint from '@eslint/js';
+import handleErrors from 'eslint-plugin-handle-errors';
+
+export default [
+    {
+        settings: {
+            handleErrors: {
+                loggerFunctions: ['Sentry.captureException', 'reportError'],
+            },
+        },
+    },
+    eslint.configs.recommended,
+    handleErrors.configs.recommended,
+];
 ```
 
 ## Rules

--- a/examples/eslint-v7/.eslintrc.cjs
+++ b/examples/eslint-v7/.eslintrc.cjs
@@ -1,7 +1,7 @@
 /* eslint-env node */
 module.exports = {
     root: true,
-    extends: ['plugin:handle-errors/recommended', 'plugin:eslint-comments/recommended'],
+    extends: ['plugin:handle-errors/legacy-recommended', 'plugin:eslint-comments/recommended'],
     parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module',

--- a/examples/eslint-v7/package-lock.json
+++ b/examples/eslint-v7/package-lock.json
@@ -9,8 +9,8 @@
             "version": "0.0.0",
             "license": "MIT",
             "devDependencies": {
-                "eslint": "^7.32.0",
-                "eslint-plugin-eslint-comments": "^3.2.0",
+                "eslint": "7.32.0",
+                "eslint-plugin-eslint-comments": "3.2.0",
                 "eslint-plugin-handle-errors": "file:../../"
             }
         },

--- a/examples/eslint-v9/eslint.config.mjs
+++ b/examples/eslint-v9/eslint.config.mjs
@@ -20,5 +20,5 @@ export default [
         },
     },
     eslint.configs.recommended,
-    handleErrors.configs['flat/recommended'],
+    handleErrors.configs.recommended,
 ];

--- a/examples/typescript-eslint/eslint.config.mjs
+++ b/examples/typescript-eslint/eslint.config.mjs
@@ -15,5 +15,5 @@ export default [
     },
     eslint.configs.recommended,
     ...tseslint.configs.recommended,
-    handleErrors.configs['flat/recommended'],
+    handleErrors.configs.recommended,
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export = {
     },
     ...index,
     configs: {
-        'flat/recommended': flatConfig,
-        recommended: legacyConfig,
+        recommended: flatConfig,
+        'legacy-recommended': legacyConfig,
     },
 };


### PR DESCRIPTION
BREAKING CHANGE:
- The recommended preset for legacy eslint config renamed from `recommended` to `legacy-recommended`
- The recommended preset for flat eslint config renamed from `flat/recommended` to `recommended`
